### PR TITLE
implement undef init and various other fixes

### DIFF
--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -1,10 +1,5 @@
 module StructArrays
 
-import Base:
-    getindex, setindex!, size, push!, view, getproperty, append!, cat, vcat, hcat
-#     linearindexing, push!, size, sort, sort!, permute!, issorted, sortperm,
-#     summary, resize!, vcat, serialize, deserialize, append!, copy!, view
-
 export StructArray
 
 const Tup = Union{Tuple, NamedTuple}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,9 +5,9 @@ using Test
 @testset "index" begin
     a, b = [1 2; 3 4], [4 5; 6 7]
     t = StructArray((a = a, b = b))
-    @test t[2,2] == (a = 4, b = 7)
-    @test t[2,1:2] == StructArray((a = [3, 4], b = [6, 7]))
-    @test view(t, 2, 1:2) == StructArray((a = view(a, 2, 1:2), b = view(b, 2, 1:2)))
+    @test (@inferred t[2,2]) == (a = 4, b = 7)
+    @test (@inferred t[2,1:2]) == StructArray((a = [3, 4], b = [6, 7]))
+    @test (@inferred view(t, 2, 1:2)) == StructArray((a = view(a, 2, 1:2), b = view(b, 2, 1:2)))
 end
 
 @testset "complex" begin
@@ -16,6 +16,15 @@ end
     @test t[2,2] == ComplexF64(4, 7)
     @test t[2,1:2] == StructArray{ComplexF64}([3, 4], [6, 7])
     @test view(t, 2, 1:2) == StructArray{ComplexF64}(view(a, 2, 1:2), view(b, 2, 1:2))
+end
+
+@testset "undef initializer" begin
+    t = @inferred StructArray{ComplexF64}(undef, 5, 5)
+    @test eltype(t) == ComplexF64
+    @test size(t) == (5,5)
+    c = 2 + im
+    t[1,1] = c
+    @test t[1,1] == c
 end
 
 @testset "resize!" begin
@@ -35,9 +44,9 @@ end
     @test t == StructArray{Pair}([3, 5, 2, 3, 5, 2], ["a", "b", "c", "a", "b", "c"])
     t = StructArray{Pair}([3, 5], ["a", "b"])
     t2 = StructArray{Pair}([1, 6], ["a", "b"])
-    @test cat(t, t2; dims=1) == StructArray{Pair}([3, 5, 1, 6], ["a", "b", "a", "b"]) == vcat(t, t2)
+    @test cat(t, t2; dims=1)::StructArray == StructArray{Pair}([3, 5, 1, 6], ["a", "b", "a", "b"]) == vcat(t, t2)
     @test vcat(t, t2) isa StructArray
-    @test cat(t, t2; dims=2) == StructArray{Pair}([3 1; 5 6], ["a" "a"; "b" "b"]) == hcat(t, t2)
+    @test cat(t, t2; dims=2)::StructArray == StructArray{Pair}([3 1; 5 6], ["a" "a"; "b" "b"]) == hcat(t, t2)
     @test hcat(t, t2) isa StructArray
 end
 


### PR DESCRIPTION
Add an undef initializer.

Also fixes so that `cat` didn't hit the fallback method:

```
t = StructArray{Pair{Int, String}}([3, 5], ["a", "b"])

julia> cat(t,t; dims=1)
4-element Array{Pair{Int64,String},1}:
 3 => "a"
 5 => "b"
 3 => "a"
 5 => "b"
```

I also changed importing on top of the file to just prefix with module name to extend methods. Importing in the top of the file is scary to me because you might forget an import. 