### PR TITLE
ensure inbounds propagate

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -38,7 +38,7 @@ Base.propertynames(s::StructArray) = fieldnames(typeof(columns(s)))
 
 Base.size(s::StructArray) = size(columns(s)[1])
 
-Base.getindex(s::StructArray, I::Int...) = get_ith(s, I...)
+Base.@propagate_inbounds Base.getindex(s::StructArray, I::Int...) = get_ith(s, I...)
 function Base.getindex(s::StructArray{T, N, C}, I::Union{Int, AbstractArray, Colon}...) where {T, N, C}
     StructArray{T}(map(v -> getindex(v, I...), columns(s)))
 end
@@ -47,7 +47,7 @@ function Base.view(s::StructArray{T, N, C}, I...) where {T, N, C}
     StructArray{T}(map(v -> view(v, I...), columns(s)))
 end
 
-Base.setindex!(s::StructArray, val, I::Int...) = set_ith!(s, val, I...)
+Base.@propagate_inbounds Base.setindex!(s::StructArray, val, I::Int...) = set_ith!(s, val, I...)
 
 fields(::Type{<:NamedTuple{K}}) where {K} = K
 fields(::Type{<:StructArray{T}}) where {T} = fields(T)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,7 +11,10 @@ eltypes(::Type{NamedTuple{K, V}}) where {K, V} = eltypes(V)
         field = Expr(:., :s, Expr(:quote, key))
         push!(args, :($field[I...]))
     end
-    Expr(:call, :createinstance, :T, args...)
+    return quote
+        @boundscheck checkbounds(s, I...)
+        @inbounds $(Expr(:call, :createinstance, :T, args...))
+    end
 end
 
 @generated function set_ith!(s::StructArray{T}, vals, I...) where {T}
@@ -22,7 +25,10 @@ end
         push!(args, :($field[I...] = $val))
     end
     push!(args, :s)
-    Expr(:block, args...)
+    return quote
+        @boundscheck checkbounds(s, I...)
+        @inbounds $(Expr(:block, args...))
+    end
 end
 
 createinstance(::Type{T}, args...) where {T} = T(args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using Test
     t = StructArray((a = a, b = b))
     @test (@inferred t[2,2]) == (a = 4, b = 7)
     @test (@inferred t[2,1:2]) == StructArray((a = [3, 4], b = [6, 7]))
+    @test_throws BoundsError t[3,3]
     @test (@inferred view(t, 2, 1:2)) == StructArray((a = view(a, 2, 1:2), b = view(b, 2, 1:2)))
 end
 


### PR DESCRIPTION
At least for scalar `getindex` and `setindex!`.

Testing this on CI is a bit hard, not sure what the best way is. Probably looking that generated code doesn't have a throw in it or something.

No boundschecks:

```jl
julia> soa = StructArray{ComplexF64}(rand(2), rand(2));

julia> g(soa, i,v ) = @inbounds soa[i] = v
g (generic function with 1 method)

julia> @code_warntype g(soa, 1, 1 + im)
Body::Complex{Int64}
1 1 ─       goto #2                                                                            │╻╷╷    setindex!
  2 ─ %2  = (Base.getfield)(v, :re)::Int64                                                     ││╻      set_ith!
  │   %3  = (StructArrays.getfield)(soa, :columns)::NamedTuple{(:re, :im),Tuple{Array{Float64,1},Array{Float64,1}}}nsion
  │   %4  = (StructArrays.getfield)(%3, :re)::Array{Float64,1}                                 ││││┃      getproperty
  │   %5  = (Base.sitofp)(Float64, %2)::Float64                                                │││││╻╷     convert
  │         (Base.arrayset)(false, %4, %5, i)                                                  │││││
  │   %7  = (Base.getfield)(v, :im)::Int64                                                     ││││╻      getproperty
  │   %8  = (StructArrays.getfield)(soa, :columns)::NamedTuple{(:re, :im),Tuple{Array{Float64,1},Array{Float64,1}}}
  │   %9  = (StructArrays.getfield)(%8, :im)::Array{Float64,1}                                 │││││
  │   %10 = (Base.sitofp)(Float64, %7)::Float64                                                │││││╻╷     convert
  │         (Base.arrayset)(false, %9, %10, i)                                                 │││││
  └──       goto #3                                                                            ││││
  3 ─       goto #4                                                                            ││
  4 ─       return v  

julia> f(soa, i) = @inbounds soa[i]

julia> @code_warntype f(soa, 1)
Body::Complex{Float64}
1 1 ─      goto #2                                                                              │╻╷╷   getindex
  2 ─ %2 = (StructArrays.getfield)(soa, :columns)::NamedTuple{(:re, :im),Tuple{Array{Float64,1},Array{Float64,1}}}
  │   %3 = (StructArrays.getfield)(%2, :re)::Array{Float64,1}                                   │││┃│    macro expansion
  │   %4 = (Base.arrayref)(false, %3, i)::Float64                                               ││││╻     getindex
  │   %5 = (StructArrays.getfield)(soa, :columns)::NamedTuple{(:re, :im),Tuple{Array{Float64,1},Array{Float64,1}}}
  │   %6 = (StructArrays.getfield)(%5, :im)::Array{Float64,1}                                   │││││
  │   %7 = (Base.arrayref)(false, %6, i)::Float64                                               ││││╻     getindex
  │   %8 = %new(Complex{Float64}, %4, %7)::Complex{Float64}                                     │││││╻     Type
  └──      goto #3                                                                              ││││
  3 ─      goto #4                                                                              ││
  4 ─      return %8  
```
