### PR TITLE
Reach feature parity with IndexedTables Columns type

### DIFF
--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -1,7 +1,7 @@
 module StructArrays
 
 import Requires
-export StructArray
+export StructArray, StructVector
 
 include("interface.jl")
 include("structarray.jl")

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -29,6 +29,10 @@ StructArray(; kwargs...) = StructArray(values(kwargs))
 
 StructArray{T}(args...) where {T} = StructArray{T}(NamedTuple{fields(T)}(args))
 
+const StructVector{T, C<:NamedTuple} = StructArray{T, 1, C}
+StructVector{T}(args...; kwargs...) where {T} = StructArray{T}(args...; kwargs...)
+StructVector(args...; kwargs...) = StructArray(args...; kwargs...)
+
 _undef_array(::Type{T}, sz; unwrap = t -> false) where {T} = unwrap(T) ? StructArray{T}(undef, sz; unwrap = unwrap) : Array{T}(undef, sz)
 
 _similar(v::AbstractArray, ::Type{Z}; unwrap = t -> false) where {Z} =

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -33,6 +33,8 @@ const StructVector{T, C<:NamedTuple} = StructArray{T, 1, C}
 StructVector{T}(args...; kwargs...) where {T} = StructArray{T}(args...; kwargs...)
 StructVector(args...; kwargs...) = StructArray(args...; kwargs...)
 
+Base.IndexStyle(::Type{StructArray{T, N, C}}) where {T, N, C} = Base.IndexStyle(gettypes(C).parameters[1])
+
 _undef_array(::Type{T}, sz; unwrap = t -> false) where {T} = unwrap(T) ? StructArray{T}(undef, sz; unwrap = unwrap) : Array{T}(undef, sz)
 
 _similar(v::AbstractArray, ::Type{Z}; unwrap = t -> false) where {Z} =
@@ -110,6 +112,10 @@ function Base.resize!(s::StructArray, i::Integer)
         resize!(a, i)
     end
     return s
+end
+
+function Base.empty!(s::StructArray)
+    foreachcolumn(empty!, s)
 end
 
 for op in [:hcat, :vcat]

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -61,6 +61,12 @@ StructArray(s::StructArray) = copy(s)
 Base.convert(::Type{StructArray}, v::AbstractArray) = StructArray(v)
 
 columns(s::StructArray) = getfield(s, :columns)
+columns(v::AbstractVector) = v
+ncols(v::AbstractVector) = 1
+ncols(v::StructArray{T, N, C}) where {T, N, C} = length(getnames(C))
+colnames(v::AbstractVector) = (1,)
+colnames(v::StructArray{T, N, C}) where {T, N, C} = getnames(C)
+
 Base.getproperty(s::StructArray, key::Symbol) = getfield(columns(s), key)
 Base.getproperty(s::StructArray, key::Int) = getfield(columns(s), key)
 Base.propertynames(s::StructArray) = fieldnames(typeof(columns(s)))

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -19,8 +19,10 @@ end
 
 StructArray{T}(c::C) where {T, C<:Tuple} = StructArray{T}(NamedTuple{fields(T)}(c))
 StructArray{T}(c::C) where {T, C<:NamedTuple} = StructArray{T, length(size(c[1])), C}(c)
+StructArray{T}(c::C) where {T, C<:Pair} = StructArray{T}(Tuple(c))
 StructArray(c::C) where {C<:NamedTuple} = StructArray{eltypes(C)}(c)
 StructArray(c::C) where {C<:Tuple} = StructArray{eltypes(C)}(c)
+StructArray(c::Pair{P, Q}) where {P, Q} = StructArray{Pair{eltype(P), eltype(Q)}}(c)
 
 StructArray{T}(; kwargs...) where {T} = StructArray{T}(values(kwargs))
 StructArray(; kwargs...) = StructArray(values(kwargs))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,14 @@ using Test
     @test (@inferred view(t, 2, 1:2)) == StructArray((a = view(a, 2, 1:2), b = view(b, 2, 1:2)))
 end
 
+@testset "columns" begin
+    t = StructArray(a = 1:10, b = rand(Bool, 10))
+    @test StructArrays.ncols(t) == 2
+    @test StructArrays.colnames(t) == (:a, :b)
+    @test StructArrays.ncols(t.a) == 1
+    @test StructArrays.colnames(t.a) == (1,)
+end
+
 @testset "constructor from existing array" begin
     v = rand(ComplexF64, 5, 3)
     t = @inferred StructArray(v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,13 @@ end
     @test StructArrays.colnames(t.a) == (1,)
 end
 
+@testset "empty" begin
+    s = StructVector(a = [1, 2, 3], b = ["a", "b", "c"])
+    empty!(s)
+    @test isempty(s.a)
+    @test isempty(s.b)
+end
+
 @testset "constructor from existing array" begin
     v = rand(ComplexF64, 5, 3)
     t = @inferred StructArray(v)


### PR DESCRIPTION
The idea is that this could potentially replace IndexedTables.Columns and this PR tries to add all features from it that are missing. It may be required to add dependencies on PooledArrays and WeakRefStrings.