### PR TITLE
Revert "support datavalue (#40)"

### DIFF
--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -20,9 +20,6 @@ function __init__()
         isstringarray(::WeakRefStrings.StringArray) = true
         default_array(::Type{T}, d) where {T<:Union{AbstractString, Missing}} = WeakRefStrings.StringArray{T}(d)
     end
-    Requires.@require DataValues="e7dc6d0d-1eca-5fa6-8ad6-5aecde8b7ea5" begin
-        Base.@pure SkipConstructor(::Type{<:DataValues.DataValue}) = true
-    end
 end
 
 end # module

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,3 @@
 Tables
 PooledArrays
 WeakRefStrings
-DataValues

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using StructArrays
 using StructArrays: LazyRow
 import Tables, PooledArrays, WeakRefStrings
-using DataValues: DataValue
 using Test
 
 # write your own tests here
@@ -408,14 +407,4 @@ end
     @test size(v) == (3, 4)
     @test v.a == [i for i in 1:3, j in 1:4]
     @test v.b == [j for i in 1:3, j in 1:4]
-end
-
-@testset "datavalues" begin
-    a = DataValue(2)
-    b = DataValue{Float64}()
-    s = StructArray(i for i in (a, b))
-    @test propertynames(s) == (:hasvalue, :value)
-    @test s.hasvalue == [true, false]
-    @test s.value isa Vector{Real}
-    @test s.value[1] == 2
 end


### PR DESCRIPTION
This reverts commit de7eafb95b18d2c23ab48275dba15ca041093899. Apparently it was not needed to readd DataValue compatibility in IndexedTables.