### PR TITLE
optimize refine perm for PooledArray columns by sorting pool once

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.7
 Requires
+PooledArrays 0.5
+WeakRefStrings 0.5.7

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -15,14 +15,15 @@ function __init__()
     Requires.@require Tables="bd369af6-aec1-5ad0-b16a-f7cc5008161c" include("tables.jl")
     Requires.@require PooledArrays="2dfb63ee-cc39-5dd5-95bd-886bf059d720" begin
         fastpermute!(v::PooledArrays.PooledArray, p::AbstractVector) = permute!(v, p)
-        function sort_by(y::PooledArrays.PooledArray)
+        function fast_sortable(y::PooledArrays.PooledArray)
             if y.pool isa Dict # Compatibility for PooledArrays < v0.5
                 pool = [y.revpool[i] for i=1:length(y.revpool)]
             else
                 pool = y.pool
             end
             poolranks = invperm(sortperm(pool))
-            j->(@inbounds k=poolranks[y.refs[j]]; k)
+            newpool = Dict(j=>convert(eltype(y.refs), i) for (i,j) in enumerate(poolranks))
+            PooledArrays.PooledArray(PooledArrays.RefArray(y.refs), newpool)
         end
     end
     Requires.@require WeakRefStrings="ea10d353-3f73-51f8-a26c-33c1cb351aa5" begin

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -15,6 +15,10 @@ function __init__()
     Requires.@require Tables="bd369af6-aec1-5ad0-b16a-f7cc5008161c" include("tables.jl")
     Requires.@require PooledArrays="2dfb63ee-cc39-5dd5-95bd-886bf059d720" begin
         fastpermute!(v::PooledArrays.PooledArray, p::AbstractVector) = permute!(v, p)
+        function sort_by(y::PooledArrays.PooledArray)
+            poolranks = invperm(sortperm(y.pool))
+            j->(@inbounds k=poolranks[y.refs[j]]; k)
+        end
     end
     Requires.@require WeakRefStrings="ea10d353-3f73-51f8-a26c-33c1cb351aa5" begin
         fastpermute!(v::WeakRefStrings.StringArray, p::AbstractVector) = permute!(v, p)

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -11,24 +11,4 @@ include("collect.jl")
 include("sort.jl")
 include("lazy.jl")
 
-function __init__()
-    Requires.@require Tables="bd369af6-aec1-5ad0-b16a-f7cc5008161c" include("tables.jl")
-    Requires.@require PooledArrays="2dfb63ee-cc39-5dd5-95bd-886bf059d720" begin
-        fastpermute!(v::PooledArrays.PooledArray, p::AbstractVector) = permute!(v, p)
-        function fast_sortable(y::PooledArrays.PooledArray)
-            if y.pool isa Dict # Compatibility for PooledArrays < v0.5
-                pool = [y.revpool[i] for i=1:length(y.revpool)]
-            else
-                pool = y.pool
-            end
-            poolranks = invperm(sortperm(pool))
-            newpool = Dict(j=>convert(eltype(y.refs), i) for (i,j) in enumerate(poolranks))
-            PooledArrays.PooledArray(PooledArrays.RefArray(y.refs), newpool)
-        end
-    end
-    Requires.@require WeakRefStrings="ea10d353-3f73-51f8-a26c-33c1cb351aa5" begin
-        fastpermute!(v::WeakRefStrings.StringArray, p::AbstractVector) = permute!(v, p)
-    end
-end
-
 end # module

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -16,7 +16,12 @@ function __init__()
     Requires.@require PooledArrays="2dfb63ee-cc39-5dd5-95bd-886bf059d720" begin
         fastpermute!(v::PooledArrays.PooledArray, p::AbstractVector) = permute!(v, p)
         function sort_by(y::PooledArrays.PooledArray)
-            poolranks = invperm(sortperm(y.pool))
+            if y.pool isa Dict # Compatibility for PooledArrays < v0.5
+                pool = [y.revpool[i] for i=1:length(y.revpool)]
+            else
+                pool = y.pool
+            end
+            poolranks = invperm(sortperm(pool))
             j->(@inbounds k=poolranks[y.refs[j]]; k)
         end
     end

--- a/src/sort.jl
+++ b/src/sort.jl
@@ -59,6 +59,7 @@ function fast_sortable(y::PooledArray)
     PooledArrays.PooledArray(PooledArrays.RefArray(y.refs), newpool)
 end
 fast_sortable(y::StringArray) = fast_sortable(PooledArray(y))
+fast_sortable(y::StringArray{String}) = fast_sortable(convert(StringArray{WeakRefString{UInt8}}, y))
 
 
 function Base.sortperm(c::StructVector{T}) where {T<:Union{Tuple, NamedTuple}}

--- a/src/sort.jl
+++ b/src/sort.jl
@@ -64,11 +64,12 @@ end
 Base.sort!(c::StructArray{<:Union{Tuple, NamedTuple}}) = permute!(c, sortperm(c))
 Base.sort(c::StructArray{<:Union{Tuple, NamedTuple}}) = c[sortperm(c)]
 
+sort_by(y) = j->(@inbounds k=y[j]; k)
 # Methods from IndexedTables to refine sorting:
 # # assuming x[p] is sorted, sort by remaining columns where x[p] is constant
 function refine_perm!(p, cols, c, x, y, lo, hi)
     temp = similar(p, 0)
-    order = Base.Order.By(j->(@inbounds k=y[j]; k))
+    order = Base.Order.By(sort_by(y))
     nc = length(cols)
     for (_, idxs) in TiedIndices(x, p, lo:hi)
         i, i1 = extrema(idxs)


### PR DESCRIPTION
So far we were using the optimized sortperm only when the first column was a PooledArray. This adds some optimizations if any other column is a PooledArray

Before
```
julia> a=rand(1:100, 10^6); b=PooledArray(rand([randstring(10) for i=1:10], 10^6));
c = StructVector((b=b, a=a))
julia> @btime sortperm(c);
  29.188 ms (47 allocations: 9.94 MiB)
```
```
c = StructVector((a=a, b=b))
julia> @btime sortperm(c);
  172.249 ms (8 allocations: 7.74 MiB)
```

After:
```julia
# speed when first column is a PooledArray remains the same
c = StructVector((b=b, a=a))
julia> @btime sortperm(c);
  28.748 ms (47 allocations: 9.93 MiB)
```

```
# this improves 3x since we don't do stringcmp at all.
c = StructVector((a=a, b=b))
julia> @btime sortperm(c);
  54.885 ms (11 allocations: 7.75 MiB)
```
