### PR TITLE
Allow columns with variable getindex return types

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -10,4 +10,5 @@ end
 staticschema(::Type{T}) where {T<:Tup} = T
 
 createinstance(::Type{T}, args...) where {T} = T(args...)
-createinstance(::Type{T}, args...) where {T<:Union{Tuple, NamedTuple}} = T(args)
+createinstance(::Type{<:Tuple}, args...)  = args
+createinstance(::Type{<:NamedTuple{names}}, args...) where {names} = NamedTuple{names}(args)


### PR DESCRIPTION
There's an interesting new package floating about that has been quite useful: https://github.com/oschulz/ArraysOfArrays.jl. The gist is that it allows viewing an M+N dimensional array as an M-dimensional array of N-dimensional arrays. To achieve this, `getindex` returns a view of the underlying data, which has a variable (but stable) return type. StructArrays relies on a constant return type in `createinstance`. This leads to some odd behavior:
```
julia> s=StructArray(x=nestedview(rand(2,3,10), 2));
julia> s[1].x .= 2;
julia> s[1].x
2×3 Array{Float64,2}:
 0.979757  0.282793  0.948475
 0.850188  0.611789  0.959696
```
This is because:
```
julia> eltype(s.x)
Array{Float64,2}
```
So in `createinstance` a call to `T(args)`, corresponding to `NamedTuple{(:x,),Tuple{Array{Float64,2}}(s.x[1])` is made, but `typeof(s.x[1])<:SubArray` so a copy of the data is made.

This PR fixes the above issue but introduces a new one: now the inferred return type for getindex(::StructArray, ...) is `Any`.

-Colin