### PR TITLE
add a note about `reinterpret`'s memory layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,5 +419,5 @@ julia> v # thus `v` will be modified as well
 ```
 
 For column-major arrays, reinterpreting along the last dimension (`dims=ndims(v)`) makes every
-component of `s` reflects a contiguous memory and thus will be more efficient. In previous example,
+component of `s` a view of contiguous memory and thus is more efficient. In the previous example,
 when `dims=2` we have `s.re == [1.0, 2.0]`, which reflects the first column of `v`.


### PR DESCRIPTION
I didn't add the `StructArray{Point{Float64}}(X, dims=2)` trick here because it is still quite strange to me; it has a strong assumption to how you interpret the data from the raw contents, but the confusion I get from #197 is how to get the "actual" memory layout __from an already constructed `StructArray`__.

closes #197 