### PR TITLE
throw if no fields

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -14,12 +14,11 @@ struct StructArray{T, N, C<:Tup, I} <: AbstractArray{T, N}
     components::C
 
     function StructArray{T, N, C}(c) where {T, N, C<:Tup}
-        if length(c) > 0
-            ax = axes(first(c))
-            length(ax) == N || error("wrong number of dimensions")
-            map(tail(c)) do ci
-                axes(ci) == ax || error("all field arrays must have same shape")
-            end
+        isempty(c) && error("Only eltypes with fields are supported")
+        ax = axes(first(c))
+        length(ax) == N || error("wrong number of dimensions")
+        map(tail(c)) do ci
+            axes(ci) == ax || error("all field arrays must have same shape")
         end
         new{T, N, C, index_type(c)}(c)
     end
@@ -333,9 +332,7 @@ staticschema(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = staticschema(
 createinstance(::Type{<:StructArray{T}}, args...) where {T} = StructArray{T}(args)
 
 Base.size(s::StructArray) = size(components(s)[1])
-Base.size(s::StructArray{<:Any, <:Any, <:EmptyTup}) = (0,)
 Base.axes(s::StructArray) = axes(components(s)[1])
-Base.axes(s::StructArray{<:Any, <:Any, <:EmptyTup}) = (1:0,)
 
 """
     StructArrays.get_ith(cols::Union{Tuple,NamedTuple}, I...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,7 +33,6 @@ end
 map_params_as_tuple_fallback(f, ::Type{T}) where {T<:Tup} = map(f, fieldtypes(T))
 
 buildfromschema(initializer::F, ::Type{T}) where {F, T} = buildfromschema(initializer, T, staticschema(T))
-buildfromschema(initializer, ::Type, ::Type{NamedTuple{(), Tuple{}}}) = error("Only structs with fields are supported")
 
 """
     StructArrays.buildfromschema(initializer, T[, S])


### PR DESCRIPTION
Before, `StructArray([nothing])` or `StructArray([1, 2, 3])` created empty (zero-length) arrays. That was silent and pretty confusing.