### PR TITLE
support similar() with non-concrete types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructArrays"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,6 +21,10 @@ julia> StructArrays.map_params(T -> Complex{T}, Tuple{Int32,Float64})
 map_params(f::F, ::Type{NamedTuple{names, types}}) where {F, names, types} =
     NamedTuple{names}(map_params(f, types))
 
+# pass Any when field types are not specified
+map_params(f::F, T::Type{NamedTuple{names}}) where {F, names} =
+    map_params(f, T{Tuple{fieldtypes(T)...}})
+
 function map_params(f::F, ::Type{T}) where {F, T<:Tuple}
     if @generated
         types = fieldtypes(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -331,6 +331,20 @@ end
     @test size(s) == (3, 5)
     @test s isa StructArray
 
+    s = similar(t, NamedTuple{(:x,)}, (3, 5))
+    @test eltype(s) == NamedTuple{(:x,)}
+    @test size(s) == (3, 5)
+    @test s isa StructArray
+    s = similar(t, NamedTuple{(:x,), Tuple{NamedTuple{(:y,)}}}, (3, 5))
+    @test eltype(s) == NamedTuple{(:x,), Tuple{NamedTuple{(:y,)}}}
+    @test size(s) == (3, 5)
+    @test s isa StructArray
+
+    s = similar(t, Any, (3, 5))
+    @test eltype(s) == Any
+    @test size(s) == (3, 5)
+    @test s isa Array
+
     s = similar(t, (0:2, 5))
     @test eltype(s) == NamedTuple{(:a, :b), Tuple{Float64, Bool}}
     @test axes(s) == (0:2, 1:5)
@@ -413,6 +427,10 @@ end
     @test size(t) == (5,)
     @test t == convert(StructVector, v)
     @test t == convert(StructVector, t)
+
+    t = StructVector([(a=1,), (a=missing,)])::StructVector
+    @test isequal(t.a, [1, missing])
+    @test eltype(t) <: NamedTuple{(:a,)}
 end
 
 @testset "tuple case" begin
@@ -1117,6 +1135,12 @@ end
     t = @inferred(map(x -> x.a, s))
     @test t isa Vector
     @test t == [1, 2, 3]
+
+    t = map(x -> (a=x.a,), StructVector(a=[1, missing]))::StructVector
+    @test isequal(t.a, [1, missing])
+    @test eltype(t) <: NamedTuple{(:a,)}
+    t = map(x -> (a=rand(["", 1, nothing]),), StructVector(a=1:10))::StructVector
+    @test eltype(t) <: NamedTuple{(:a,)}
 
     t = VERSION >= v"1.7" ? @inferred(map(x -> (a=x.a, b=2), s)) : map(x -> (a=x.a, b=2), s)
     @test t isa StructArray


### PR DESCRIPTION
newly-added tests failed before