### PR TITLE
Switch from `permute!!` to `permute!`

### DIFF
--- a/src/sort.jl
+++ b/src/sort.jl
@@ -62,7 +62,7 @@ function Base.sortperm(c::StructVector{T}) where {T<:Union{Tuple, NamedTuple}}
     return p
 end
 
-Base.sort!(c::StructArray{<:Union{Tuple, NamedTuple}}) = (permute!(c, sortperm(refarray(c))); c)
+Base.sort!(c::StructArray{<:Union{Tuple, NamedTuple}}) = (permute!(c, sortperm(c)); c)
 Base.sort(c::StructArray{<:Union{Tuple, NamedTuple}}) = c[sortperm(c)]
 
 # Given an ordering `p`, return a vector `v` such that `Perm(Forward, v)` is


### PR DESCRIPTION
In Julia 1.9.0, `permute!` is typically faster that the internal method `Base.permute!!`, thanks to https://github.com/JuliaLang/julia/pull/44941.

For struct arrays in particular, using the internal method `Base.permute!!` seems to give moderate performance improvements for small arrays in exchange for moderate regressions for huge arrays when compared to `permute!`

```julia
using Random, BenchmarkTools, StructArrays

small = StructArray(zip(rand(10), rand(10)));
x = rand(10_000);
y = [randstring() for _ in 1:10_000];
big = StructArray(zip(x, y, rand(ComplexF64, 10_000), x, x, y));
x = rand(1_000_000);
y = [randstring() for _ in 1:1_000_000];
z = rand(ComplexF64, 1_000_000);
huge = StructArray(zip(x, y, x, z, z, x, z, x, y, y, z, x, y));

for sa in (small, big, huge)
    @btime (Base.permute!!($sa, sortperm($sa)); $sa) setup=(shuffle!($sa)) evals=1;
    @btime (permute!($sa, sortperm($sa)); $sa) setup=(shuffle!($sa)) evals=1;
end
# 166.000 ns (2 allocations: 208 bytes)
# 208.000 ns (4 allocations: 496 bytes)
# 359.583 μs (5 allocations: 156.41 KiB)
# 340.708 μs (17 allocations: 703.56 KiB)
# 192.807 ms (5 allocations: 15.26 MiB)
# 107.488 ms (31 allocations: 144.96 MiB)
```

I would say `permute!` is better on balance, and even if it were even, using a public method with a simple implementation is typically better than using an internal method with a complex implementation for maintainability and compile time.