### PR TITLE
optimize get_ith

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -338,10 +338,7 @@ to
 map(c -> c[I...], Tuple(cols))
 ```
 """
-@inline @generated get_ith(cols::Union{
-        NTuple{N, Any},
-        NamedTuple{<:Any,<:NTuple{N, Any}}
-    }, I...) where {N} = :(Base.Cartesian.@ntuple $N i -> @inbounds cols[i][I...])
+@inline @generated get_ith(cols::Tup, I...) = :(Base.Cartesian.@ntuple $(fieldcount(cols)) i -> @inbounds cols[i][I...])
 
 Base.@propagate_inbounds Base.getindex(x::StructArray, I...) = _getindex(x, to_indices(x, I)...)
 


### PR DESCRIPTION
Makes getindex and related functions much faster on arrays with a few tens of components.

Narrow arrays:
```julia
julia> a1 = StructArray(x=1:10, y=1:10, z=1:10)
julia> @btime $a1[2]
# before
  1.625 ns (0 allocations: 0 bytes)
# after
  1.666 ns (0 allocations: 0 bytes)
```
Intermediate arrays:
```julia
julia> a2 = StructArray(;[Symbol("x$i") => 1:10 for i in 1:50]...)

julia> @btime $a2[2]
# before
  42.166 μs (854 allocations: 45.86 KiB)
# after
  3.182 μs (56 allocations: 4.91 KiB)
```

I guess originally there was some reason why the current implementation was chosen instead of a more naive one? The latter turns out to be faster now.