### PR TITLE
0.7 was tagged without any breaking changes - should be 0.6.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructArrays"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.7.0"
+version = "0.6.20"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"


### PR DESCRIPTION
0.7 was bumped in https://github.com/JuliaArrays/StructArrays.jl/pull/317, motivated as

> Set version to 0.7, since bumping Julia version requires minor version bump.

But I don't think this is actually the case. Both common sense (bumping julia version compat is non-breaking for package users) and [ColPrac](https://github.com/SciML/ColPrac#changing-dependency-compatibility):

> Changing Julia version compatibility must be a non-breaking feature.
> It cannot alone be breaking, since Julia versions that are now unsupported will just never see this newer package release.
> If the package is pre-1.0, minor releases count as breaking. Therefore, tag the release as a patch release 

agree that it's non-breaking.