### PR TITLE
support ConstructionBase: constructorof and setproperties

### DIFF
--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -13,6 +13,7 @@ include("utils.jl")
 include("collect.jl")
 include("sort.jl")
 include("lazy.jl")
+include("constructionbase.jl")
 include("tables.jl")
 
 # Implement refarray and refvalue to deal with pooled arrays and weakrefstrings effectively

--- a/src/constructionbase.jl
+++ b/src/constructionbase.jl
@@ -1,0 +1,17 @@
+using ConstructionBase
+
+# (named)tuple eltypes: components/fields are all that's needed for the StructArray() constructor
+ConstructionBase.constructorof(::Type{<:StructArray{<:Union{Tuple, NamedTuple}}}) = StructArray
+
+# other eltypes: need to pass eltype to the constructor in addition to components
+ConstructionBase.constructorof(::Type{<:StructArray{T}}) where {T} = function(comps::CT) where {CT}
+    # the resulting eltype is like T, but potentially with different type parameters, eg Complex{Int} -> Complex{Float64}
+    # probe its constructorof to get the right concrete type
+    ET = Base.promote_op(constructorof(T), map(eltype, fieldtypes(CT))...)
+    StructArray{ET}(comps)
+end
+
+# two methods with the same body, required to avoid ambiguities
+# just redirect setproperties to constructorof
+ConstructionBase.setproperties(x::StructArray, patch::NamedTuple) = constructorof(typeof(x))(setproperties(getproperties(x), patch))
+ConstructionBase.setproperties(x::StructArray, patch::Tuple) = constructorof(typeof(x))(setproperties(getproperties(x), patch))


### PR DESCRIPTION
StructArrays are quite involved types, it's infeasible for some generic machinery to know how to reconstruct them from their fields/properties. Thus this PR adds explicit support for both `constructorof()` and `setproperties()` from ConstructionBase. With these, all the packages that need to reconstruct arbitrary objects / rely on ConstructionBase already, can work with StructArrays as well.

The implementation is short, but needs some care to get right. That's the benefit of having it in one place, with tests for handling of all simple and complex cases.
`ConstructionBase` has already been a dependency of `StructArrays`, no new deps added in this PR.