### PR TITLE
select components like namedtuple elements

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -344,6 +344,8 @@ map(c -> c[I...], Tuple(cols))
 
 Base.@propagate_inbounds Base.getindex(x::StructArray, I...) = _getindex(x, to_indices(x, I)...)
 
+Base.getindex(s::StructArray{<:NamedTuple, <:Any, <:NamedTuple}, keys::Tuple{Vararg{Symbol}}) = StructArray(components(s)[keys])
+
 Base.@propagate_inbounds function _getindex(x::StructArray{T}, I::Vararg{Int}) where {T}
     cols = components(x)
     @boundscheck checkbounds(x, I...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,9 @@ Base.convert(::Type{Millimeters}, x::Meters) = Millimeters(x.x*1000)
 
     s = StructArray(a=1:5)
     @test s[2:3].a === 2:3
+
+    t2 = StructArray(x = [1, 2], y = [3, 4], z = [5, 6])
+    @test t2[(:x, :y)] == StructArray(x = [1, 2], y = [3, 4])
 end
 
 @testset "eltype conversion" begin


### PR DESCRIPTION
In Julia, `nt[(:x, :y)]` returns a namedtuple with only these components.
With this PR, `sa[(:x, :y)]` returns a structarray with only these components.
(namedtuple-only for now)