### PR TITLE
Correct typo in second example of docs/index.md

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,7 +22,7 @@ x = StructArray{Foo}((adata, bdata))
 You can also initialize a `StructArray` by passing in a `NamedTuple`, in which case the name (rather than the order) specifies how the input arrays are assigned to fields:
 
 ```@repl intro
-x = Array{Foo}((b = adata, a = bdata))    # initialize a with bdata and vice versa
+x = StructArray{Foo}((b = adata, a = bdata))    # initialize a with bdata and vice versa
 ```
 
 If a `struct` is not specified, a `StructArray` with `Tuple `or `NamedTuple` elements will be created:


### PR DESCRIPTION
Hi,
While reading the docs, I noticed an error in the second example (use of `Array` instead of `StructArray`).
Since it's such a small correction, feel free to cancel the merge request and apply the patch in a commit done by a maintainer.